### PR TITLE
Identify arrow functions

### DIFF
--- a/src/rule.test.ts
+++ b/src/rule.test.ts
@@ -53,6 +53,14 @@ ruleTester.run('rule', rule, {
             `,
 			options: [],
 		},
+		{
+			name: 'Arrow function assigned to a const, then called, with return value assigned to a variable',
+			code: `
+            const foo = (): number => { return 1 };
+            let f = foo()
+            `,
+			options: [],
+		},
 	],
 	invalid: [
 		{
@@ -71,6 +79,14 @@ ruleTester.run('rule', rule, {
                 foo();
                 return 1;
             }
+            `,
+			errors: [{ messageId: 'unused' }],
+		},
+		{
+			name: 'Arrow function assigned to a const, then called and return value ignored',
+			code: `
+            const foo = (): number => { return 1 };
+            foo()
             `,
 			errors: [{ messageId: 'unused' }],
 		},

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -78,6 +78,7 @@ export const rule = createRule({
 						functionNode => hasNonVoidReturnType(functionNode)
 					);
 
+					// We'd only expect nonVoidReturnFunctions to have 0 or 1 elements at this point
 					if (nonVoidReturnFunctions.length > 0) {
 						const maybeCallExpression = getCallExpression(ref);
 						if (

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -74,21 +74,22 @@ export const rule = createRule({
 						}
 					);
 
-					[...namedFunctions, ...arrowFunctions].forEach((functionNode) => {
-						const nonVoid = hasNonVoidReturnType(functionNode);
-						if (nonVoid) {
-							const maybeCallExpression = getCallExpression(ref);
-							if (
-								maybeCallExpression &&
-								!isReturnValueUsed(maybeCallExpression)
-							) {
-								context.report({
-									messageId: 'unused',
-									node: ref.identifier,
-								});
-							}
+					const nonVoidReturnFunctions = [...namedFunctions, ...arrowFunctions].filter(
+						functionNode => hasNonVoidReturnType(functionNode)
+					);
+
+					if (nonVoidReturnFunctions.length > 0) {
+						const maybeCallExpression = getCallExpression(ref);
+						if (
+							maybeCallExpression &&
+							!isReturnValueUsed(maybeCallExpression)
+						) {
+							context.report({
+								messageId: 'unused',
+								node: ref.identifier,
+							});
 						}
-					});
+					}
 				}
 			});
 		};

--- a/src/utils/collect.ts
+++ b/src/utils/collect.ts
@@ -1,0 +1,11 @@
+// Combines filter + map in a single pass. Inspired by Scala's collect
+export const collect = <A, B>(arr: A[], f: (a: A) => B | undefined): B[] => {
+	const results: B[] = [];
+	arr.forEach((a) => {
+		const b: B | undefined = f(a);
+		if (b) {
+			results.push(b);
+		}
+	});
+	return results;
+};


### PR DESCRIPTION
Our initial implementation supports named functions, e.g.
`function foo(): number { return 1; }`

This PR adds logic to identify arrow (aka anonymous) functions:
`const foo = (): number => { return 1 };`

This is a bit more involved - the reference definition is now `VariableDeclarator` instead of `FunctionName`, and we have to inspect its initialisation type to check if it's an `ArrowFunctionExpression`.
This is just a first attempt - it's possible there are more cases of arrow functions that this does not catch (e.g. [here](https://github.com/guardian/eslint-plugin-no-unused-return-value/issues/2))