### PR TITLE
Handle function expressions

### DIFF
--- a/src/rule.test.ts
+++ b/src/rule.test.ts
@@ -61,6 +61,14 @@ ruleTester.run('rule', rule, {
             `,
 			options: [],
 		},
+		{
+			name: 'Function assigned to a const, then called, with return value assigned to a variable',
+			code: `
+			const foo = function(): number { return 1 }
+            let f = foo()
+            `,
+			options: [],
+		},
 	],
 	invalid: [
 		{
@@ -86,6 +94,14 @@ ruleTester.run('rule', rule, {
 			name: 'Arrow function assigned to a const, then called and return value ignored',
 			code: `
             const foo = (): number => { return 1 };
+            foo()
+            `,
+			errors: [{ messageId: 'unused' }],
+		},
+		{
+			name: 'Function assigned to a const, then called and return value ignored',
+			code: `
+			const foo = function(): number { return 1 }
             foo()
             `,
 			errors: [{ messageId: 'unused' }],

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -10,7 +10,6 @@ import {
 	Node,
 } from '@typescript-eslint/types/dist/generated/ast-spec';
 import {
-	DefinitionType,
 	Reference,
 	Scope,
 } from '@typescript-eslint/scope-manager';
@@ -62,7 +61,7 @@ export const rule = createRule({
 			scope.references.map((ref) => {
 				if (ref.resolved) {
 					const namedFunctions: FunctionNode[] = collect(ref.resolved.defs, def => {
-						if (def.type === DefinitionType.FunctionName) {
+						if (isFunctionNode(def.node)) {
 							return def.node;
 						}
 					});


### PR DESCRIPTION
A previous PR added support for finding arrow functions defined with e.g.
`const foo = (): number => { return 1 };`

This PR broadens this to support any functions assigned to variables. Specifically:
`const foo = function(): number { return 1 }`