### PR TITLE
Handle parameter functions

### DIFF
--- a/src/rule.test.ts
+++ b/src/rule.test.ts
@@ -69,6 +69,15 @@ ruleTester.run('rule', rule, {
             `,
 			options: [],
 		},
+		{
+			name: 'Function receives a function, calls it, and returns the result',
+			code: `
+			function foo(f: () => number): number {
+			  return f()
+			}
+            `,
+			options: [],
+		}
 	],
 	invalid: [
 		{
@@ -103,6 +112,15 @@ ruleTester.run('rule', rule, {
 			code: `
 			const foo = function(): number { return 1 }
             foo()
+            `,
+			errors: [{ messageId: 'unused' }],
+		},
+		{
+			name: 'Function receives a function, calls it, but ignores the return value',
+			code: `
+			function foo(f: () => number): void {
+			  f()
+			}
             `,
 			errors: [{ messageId: 'unused' }],
 		},

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -1,18 +1,15 @@
-import { ESLintUtils } from '@typescript-eslint/utils';
+import {ESLintUtils} from '@typescript-eslint/utils';
 import {
+	ArrowFunctionExpression,
 	AST_NODE_TYPES,
 	CallExpression,
 	FunctionDeclaration,
 	FunctionExpression,
+	Node,
 	TSDeclareFunction,
 	TSEmptyBodyFunctionExpression,
-	ArrowFunctionExpression,
-	Node,
 } from '@typescript-eslint/types/dist/generated/ast-spec';
-import {
-	Reference,
-	Scope,
-} from '@typescript-eslint/scope-manager';
+import {Definition, DefinitionType, Reference, Scope} from '@typescript-eslint/scope-manager';
 import {collect} from "./utils/collect";
 
 const createRule = ESLintUtils.RuleCreator(
@@ -42,9 +39,31 @@ type FunctionNode =
 	| TSDeclareFunction
 	| TSEmptyBodyFunctionExpression
 	| ArrowFunctionExpression;
-const functionNodeTypes = [AST_NODE_TYPES.FunctionDeclaration, AST_NODE_TYPES.FunctionExpression, AST_NODE_TYPES.TSDeclareFunction, AST_NODE_TYPES.TSEmptyBodyFunctionExpression, AST_NODE_TYPES.TSEmptyBodyFunctionExpression, AST_NODE_TYPES.ArrowFunctionExpression];
+const functionNodeTypes = [AST_NODE_TYPES.FunctionDeclaration, AST_NODE_TYPES.FunctionExpression, AST_NODE_TYPES.TSDeclareFunction, AST_NODE_TYPES.TSEmptyBodyFunctionExpression, AST_NODE_TYPES.TSEmptyBodyFunctionExpression, AST_NODE_TYPES.ArrowFunctionExpression, AST_NODE_TYPES.TSFunctionType];
 const isFunctionNode = (node: Node): node is FunctionNode =>
 	functionNodeTypes.includes(node.type);
+
+// Look for a function passed as a parameter, e.g. function foo(param: () => number)
+const checkForParameterWhichIsAFunction = (def: Definition): FunctionNode | undefined => {
+	if (def.type === DefinitionType.Parameter) {
+		const name = def.name;
+		if (name?.typeAnnotation) {
+			// This seems to be the only way to get info about the parameter if it's a function
+			if (isFunctionNode(name.typeAnnotation.typeAnnotation)) {
+				return name.typeAnnotation.typeAnnotation;
+			}
+		}
+	}
+}
+
+// Look for a function assigned to a variable, e.g. const f = (): number => { return 1 };
+const checkForVariableWithFunction = (def: Definition): FunctionNode | undefined => {
+	if (def.node.type === AST_NODE_TYPES.VariableDeclarator &&
+		def.node.init &&
+		isFunctionNode(def.node.init)) {
+		return def.node.init;
+	}
+}
 
 const hasNonVoidReturnType = (node: FunctionNode): boolean =>
 	// If no returnType is declared then we cannot run this rule
@@ -60,25 +79,23 @@ export const rule = createRule({
 
 			scope.references.map((ref) => {
 				if (ref.resolved) {
-					const namedFunctions: FunctionNode[] = collect(ref.resolved.defs, def => {
+					const functionNodes: FunctionNode[] = collect(ref.resolved.defs, def => {
+						const functionParameter = checkForParameterWhichIsAFunction(def);
+						if (functionParameter) {
+							return functionParameter
+						}
+
+						const variable = checkForVariableWithFunction(def);
+						if (variable) {
+							return variable;
+						}
+
 						if (isFunctionNode(def.node)) {
 							return def.node;
 						}
 					});
 
-					// Functions assigned to variables
-					const functionExpressions: FunctionNode[] = collect(
-						ref.resolved.defs,
-						def => {
-							if (def.node.type === AST_NODE_TYPES.VariableDeclarator &&
-								def.node.init &&
-								isFunctionNode(def.node.init)) {
-								return def.node.init;
-							}
-						}
-					);
-
-					const nonVoidReturnFunctions = [...namedFunctions, ...functionExpressions].filter(
+					const nonVoidReturnFunctions = functionNodes.filter(
 						functionNode => hasNonVoidReturnType(functionNode)
 					);
 


### PR DESCRIPTION
Checks for functions passed as parameters to other functions. E.g. it should catch the unused return value in:
```
function foo(f: () => number): void {
  f();
}
```

This led to a small refactor to iterate over `ref.resolved.defs` once, checking for each type of function reference.