### PR TITLE
Inline object property assignment

### DIFF
--- a/src/rule.test.ts
+++ b/src/rule.test.ts
@@ -143,6 +143,16 @@ ruleTester.run('rule', rule, {
 		    `,
 			options: [],
 		},
+		{
+			name: 'Inline function used as object property value',
+			code: `
+			const foo = (): string => 'blah';
+			const bar = {
+				baz: foo(),
+			};
+			`,
+			options: [],
+		}
 	],
 	invalid: [
 		{

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -25,7 +25,15 @@ const getCallExpression = (ref: Reference): CallExpression | undefined => {
 	}
 };
 
-const validUsageNodeTypes: AST_NODE_TYPES[] = [AST_NODE_TYPES.VariableDeclarator, AST_NODE_TYPES.ReturnStatement, AST_NODE_TYPES.BinaryExpression, AST_NODE_TYPES.TemplateLiteral, AST_NODE_TYPES.ArrowFunctionExpression, AST_NODE_TYPES.MemberExpression];
+const validUsageNodeTypes: AST_NODE_TYPES[] = [
+	AST_NODE_TYPES.VariableDeclarator,
+	AST_NODE_TYPES.ReturnStatement,
+	AST_NODE_TYPES.BinaryExpression,
+	AST_NODE_TYPES.TemplateLiteral,
+	AST_NODE_TYPES.ArrowFunctionExpression,
+	AST_NODE_TYPES.MemberExpression,
+	AST_NODE_TYPES.Property,
+];
 const isValidUsageNodeType = (type: AST_NODE_TYPES | undefined) => !!type && validUsageNodeTypes.includes(type);
 const isReturnValueUsed = (callExpr: CallExpression): boolean =>
 	callExpr.callee.type !== AST_NODE_TYPES.Identifier ||


### PR DESCRIPTION
## What does this change?

Previously calling a function inline and assigning the return value to an object property was incorrectly flagged. This is fixed by this PR.