### PR TITLE
Handle function call from JSX expression

### DIFF
--- a/src/rule.test.ts
+++ b/src/rule.test.ts
@@ -3,6 +3,11 @@ import { rule } from './rule';
 
 const ruleTester = new ESLintUtils.RuleTester({
 	parser: '@typescript-eslint/parser',
+	parserOptions: {
+		ecmaFeatures: {
+			jsx: true,
+		},
+	}
 });
 
 /**
@@ -152,7 +157,19 @@ ruleTester.run('rule', rule, {
 			};
 			`,
 			options: [],
-		}
+		},
+		{
+			name: 'Return value of function used for JSX prop',
+			code: `
+			const Foo = ({ foo }) => {
+					return <div>{foo}</div>;
+			};
+			const bar = (): string => 'bar';
+
+			<Foo foo={bar()} />
+			`,
+			options: [],
+		},
 	],
 	invalid: [
 		{

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -33,6 +33,7 @@ const validUsageNodeTypes: AST_NODE_TYPES[] = [
 	AST_NODE_TYPES.ArrowFunctionExpression,
 	AST_NODE_TYPES.MemberExpression,
 	AST_NODE_TYPES.Property,
+	AST_NODE_TYPES.JSXExpressionContainer,
 ];
 const isValidUsageNodeType = (type: AST_NODE_TYPES | undefined) => !!type && validUsageNodeTypes.includes(type);
 const isReturnValueUsed = (callExpr: CallExpression): boolean =>


### PR DESCRIPTION
## What does this change?

Previously, if a function call was used in a JSX expression we wouldn't have considered the return value used. This PR fixes this. For example, in this snippet the return value of `bar()` is now considered used:

```tsx
const Foo = ({ foo }) => {
   return <div>{foo}</div>;
};
const bar = (): string => 'bar';
<Foo foo={bar()} />
```