### PR TITLE
Git ignore target dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+target


### PR DESCRIPTION
## What does this change?

Update `.gitignore` to include the `target` dir, which is where we write the built JS.