### PR TITLE
Handle Promise methods

### DIFF
--- a/src/rule.test.ts
+++ b/src/rule.test.ts
@@ -92,10 +92,10 @@ ruleTester.run('rule', rule, {
 			options: [],
 		},
 		{
-			name: 'Function passed to Array.map',
+			name: 'Function passed to Array.map but not called directly',
 			code: `
 			const double = (n: number): number => n*2;
-			[1,2].map(double);
+			const result = [1,2].map(double);
 		    `,
 			options: [],
 		},
@@ -103,7 +103,7 @@ ruleTester.run('rule', rule, {
 			name: 'Function called by a function passed to Array.map',
 			code: `
 			const double = (n: number): number => n*2;
-			[1,2].map(n => double(n));
+			const result = [1,2].map(n => double(n));
 		    `,
 			options: [],
 		},
@@ -111,7 +111,7 @@ ruleTester.run('rule', rule, {
 			name: 'Function called in an expression by a function passed to Array.map',
 			code: `
 			const double = (n: number): number => n*2;
-			[1,2].map(n => 1 + double(n));
+			const result = [1,2].map(n => 1 + double(n));
 		    `,
 			options: [],
 		},
@@ -120,15 +120,6 @@ ruleTester.run('rule', rule, {
 			code: `
 			const foo = (): Promise<number> => Promise.resolve(1);
 			let f = await foo()
-		    `,
-			options: [],
-		},
-		{
-			name: 'Call Promise.then on result of async function',
-			code: `
-			function foo(f: () => Promise<number>): void {
-			  f().then(n => console.log(n))
-			}
 		    `,
 			options: [],
 		},
@@ -169,6 +160,14 @@ ruleTester.run('rule', rule, {
 			<Foo foo={bar()} />
 			`,
 			options: [],
+		},
+		{
+			name: 'Result of Promise.then method call is used',
+			code: `
+			function foo(f: Promise<number>): Promise<void> {
+			    return f.then(n => n*2);
+			}
+			`,
 		},
 	],
 	invalid: [
@@ -223,6 +222,15 @@ ruleTester.run('rule', rule, {
 			await foo()
 		    `,
 			errors: [{ messageId: 'unused' }],
+		},
+		{
+			name: 'Result of Promise.then method call is not used',
+			code: `
+			function foo(f: Promise<number>) {
+			  f.then(n => n*2);
+			}
+			`,
+			errors: [{ messageId: 'unusedPromiseMethod' }],
 		},
 	],
 });

--- a/src/rule.test.ts
+++ b/src/rule.test.ts
@@ -92,28 +92,12 @@ ruleTester.run('rule', rule, {
 			options: [],
 		},
 		{
-			name: 'Function passed to Array.map but not called directly',
+			name: 'FunctionA passed to FunctionB, and result of FunctionB is used',
 			code: `
 			const double = (n: number): number => n*2;
-			const result = [1,2].map(double);
-		    `,
-			options: [],
-		},
-		{
-			name: 'Function called by a function passed to Array.map',
-			code: `
-			const double = (n: number): number => n*2;
-			const result = [1,2].map(n => double(n));
-		    `,
-			options: [],
-		},
-		{
-			name: 'Function called in an expression by a function passed to Array.map',
-			code: `
-			const double = (n: number): number => n*2;
-			const result = [1,2].map(n => 1 + double(n));
-		    `,
-			options: [],
+			const apply = (n: number, f: (n: number) => number): number => f(n);
+			const result = apply(2, double); 
+			`,
 		},
 		{
 			name: 'Async function is awaited and result assigned to variable',
@@ -231,6 +215,15 @@ ruleTester.run('rule', rule, {
 			}
 			`,
 			errors: [{ messageId: 'unusedPromiseMethod' }],
+		},
+		{
+			name: 'FunctionA passed to FunctionB, and result of FunctionB is not used',
+			code: `
+			const double = (n: number): number => n*2;
+			const apply = (n: number, f: (n: number) => number): number => f(n);
+			apply(2, double); 
+			`,
+			errors: [{ messageId: 'unused' }],
 		},
 	],
 });

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -16,9 +16,11 @@ const createRule = ESLintUtils.RuleCreator(
 	(name) => `https://example.com/rule/${name}`,
 );
 
-const isFunctionCalled = (ref: Reference): boolean =>
-	ref.identifier.type === AST_NODE_TYPES.Identifier &&
-	ref.identifier.parent?.type === AST_NODE_TYPES.CallExpression;
+const isFunctionCalled = (ref: Reference): boolean => {
+	const parent = ref.identifier.parent as CallExpression;
+	return parent.callee === ref.identifier &&
+		ref.identifier.parent?.type === AST_NODE_TYPES.CallExpression;
+}
 
 const validUsageNodeTypes: AST_NODE_TYPES[] = [
 	AST_NODE_TYPES.VariableDeclarator,

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -1,15 +1,16 @@
-import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+import {AST_NODE_TYPES, ESLintUtils} from '@typescript-eslint/utils';
 import {
 	ArrowFunctionExpression,
 	CallExpression,
 	FunctionDeclaration,
 	FunctionExpression,
+	MemberExpression,
 	Node,
 	TSDeclareFunction,
 	TSEmptyBodyFunctionExpression,
 } from '@typescript-eslint/types/dist/generated/ast-spec';
-import { Definition, DefinitionType, Reference, Scope } from '@typescript-eslint/scope-manager';
-import { collect } from "./utils/collect";
+import {Definition, DefinitionType, Reference, Scope} from '@typescript-eslint/scope-manager';
+import {collect} from "./utils/collect";
 
 const createRule = ESLintUtils.RuleCreator(
 	(name) => `https://example.com/rule/${name}`,
@@ -19,26 +20,17 @@ const isFunctionCalled = (ref: Reference): boolean =>
 	ref.identifier.type === AST_NODE_TYPES.Identifier &&
 	ref.identifier.parent?.type === AST_NODE_TYPES.CallExpression;
 
-const getCallExpression = (ref: Reference): CallExpression | undefined => {
-	if (isFunctionCalled(ref)) {
-		return ref.identifier.parent as CallExpression;
-	}
-};
-
 const validUsageNodeTypes: AST_NODE_TYPES[] = [
 	AST_NODE_TYPES.VariableDeclarator,
 	AST_NODE_TYPES.ReturnStatement,
 	AST_NODE_TYPES.BinaryExpression,
 	AST_NODE_TYPES.TemplateLiteral,
 	AST_NODE_TYPES.ArrowFunctionExpression,
-	AST_NODE_TYPES.MemberExpression,
-	AST_NODE_TYPES.Property,
 	AST_NODE_TYPES.JSXExpressionContainer,
+	AST_NODE_TYPES.Property,	// property assignment
 ];
 const isValidUsageNodeType = (type: AST_NODE_TYPES | undefined) => !!type && validUsageNodeTypes.includes(type);
 const isReturnValueUsed = (callExpr: CallExpression): boolean =>
-	callExpr.callee.type !== AST_NODE_TYPES.Identifier ||
-	// If callee is Identifier, check the parent is valid:
 	isValidUsageNodeType(callExpr.parent?.type) ||
 	(callExpr.parent?.type === AST_NODE_TYPES.AwaitExpression && isValidUsageNodeType(callExpr.parent?.parent?.type));
 
@@ -81,45 +73,85 @@ const hasNonVoidReturnType = (node: FunctionNode): boolean =>
 		node.returnType.typeAnnotation.type !== AST_NODE_TYPES.TSVoidKeyword
 	);
 
+const isMemberExpressionNode = (node: Node): node is MemberExpression =>
+	node.type === AST_NODE_TYPES.MemberExpression;
+const isCallExpressionNode = (node: Node): node is CallExpression =>
+	node.type === AST_NODE_TYPES.CallExpression;
+
+// If ref is an identifier for an object and one of methodNames is being called then return the CallExpression
+const getCallExpressionForNamedMethod = (ref: Reference, methodNames: string[]): CallExpression | undefined => {
+	if (ref.identifier.type === AST_NODE_TYPES.Identifier && ref.identifier.parent) {
+		const parent = ref.identifier.parent;
+		if (isMemberExpressionNode(parent) && parent.parent && isCallExpressionNode(parent.parent)) {
+			if (parent.property.type === AST_NODE_TYPES.Identifier) {
+				if (methodNames.includes(parent.property.name)) {
+					return parent.parent;
+				}
+			}
+		}
+	}
+}
+
+// If ref is a function and is being called then return the CallExpression
+const getCallExpressionForFunction = (ref: Reference): CallExpression | undefined => {
+	if (isFunctionReference(ref) && isFunctionCalled(ref)) {
+		return ref.identifier.parent as CallExpression;
+	}
+};
+
+const isFunctionReference = (ref: Reference): boolean => {
+	if (ref.resolved) {
+		const functionNodes: FunctionNode[] = collect(ref.resolved.defs, def => {
+			const functionParameter = checkForParameterWhichIsAFunction(def);
+			if (functionParameter) {
+				return functionParameter
+			}
+
+			const variable = checkForVariableWithFunction(def);
+			if (variable) {
+				return variable;
+			}
+
+			if (isFunctionNode(def.node)) {
+				return def.node;
+			}
+		});
+
+		const nonVoidReturnFunctions = functionNodes.filter(
+			functionNode => hasNonVoidReturnType(functionNode)
+		);
+
+		// We'd only expect nonVoidReturnFunctions to have 0 or 1 elements at this point
+		return nonVoidReturnFunctions.length > 0;
+	}
+	return false;
+}
+
 export const rule = createRule({
 	create(context) {
 		const traverseScope = (scope: Scope): void => {
 			scope.childScopes.forEach((childScope) => traverseScope(childScope));
 
 			scope.references.map((ref) => {
-				if (ref.resolved) {
-					const functionNodes: FunctionNode[] = collect(ref.resolved.defs, def => {
-						const functionParameter = checkForParameterWhichIsAFunction(def);
-						if (functionParameter) {
-							return functionParameter
-						}
 
-						const variable = checkForVariableWithFunction(def);
-						if (variable) {
-							return variable;
-						}
-
-						if (isFunctionNode(def.node)) {
-							return def.node;
-						}
+				// Hardcode the handling of Promise.then + Promise.catch - it should always expect the value to be used.
+				// For other method calls, we cannot know the return type of the method without finding the class def - so this is unsupported for now.
+				const methodCallExpression = getCallExpressionForNamedMethod(ref, ['then', 'catch']);
+				if (methodCallExpression && !isReturnValueUsed(methodCallExpression)) {
+					context.report({
+						messageId: 'unusedPromiseMethod',
+						node: ref.identifier,
 					});
-
-					const nonVoidReturnFunctions = functionNodes.filter(
-						functionNode => hasNonVoidReturnType(functionNode)
-					);
-
-					// We'd only expect nonVoidReturnFunctions to have 0 or 1 elements at this point
-					if (nonVoidReturnFunctions.length > 0) {
-						const maybeCallExpression = getCallExpression(ref);
-						if (
-							maybeCallExpression &&
-							!isReturnValueUsed(maybeCallExpression)
-						) {
-							context.report({
-								messageId: 'unused',
-								node: ref.identifier,
-							});
-						}
+				} else {
+					const functionCallExpression = getCallExpressionForFunction(ref);
+					if (
+						functionCallExpression &&
+						!isReturnValueUsed(functionCallExpression)
+					) {
+						context.report({
+							messageId: 'unused',
+							node: ref.identifier,
+						});
 					}
 				}
 			});
@@ -140,6 +172,7 @@ export const rule = createRule({
 		},
 		messages: {
 			unused: 'Use the return value',
+			unusedPromiseMethod: 'Use the returned Promise'
 		},
 		type: 'suggestion',
 		schema: [],


### PR DESCRIPTION
E.g. here the result of `f.then(...)` is unused, and so should be invalid:
```
function foo(f: Promise<number>) {
  f.then(n => n*2);
}
```

Handling of methods turned out to be a lot harder than functions.
Here's the AST of the above code:
![Screenshot 2023-02-02 at 09 20 45](https://user-images.githubusercontent.com/1513454/216283349-64e108d3-04bd-4f96-9329-205838025c3c.png)

We can tell that `then` is a method (`MemberExpression.property`), and that it's being called (`CallExpression` parent), but there's no link to the type of `then`.
So we've had to add special handling for Promise then/catch, with the assumption that the returned Promise should always be used.
This also means we cannot easily support methods in general - it would need to find the class definition elsewhere in the AST.